### PR TITLE
GUI fix for very long GPU model name

### DIFF
--- a/data/cpu-x-gtk-3.12.ui
+++ b/data/cpu-x-gtk-3.12.ui
@@ -3979,12 +3979,12 @@
                                             <property name="can-focus">True</property>
                                             <property name="hexpand">True</property>
                                             <property name="justify">center</property>
-                                            <property name="wrap">True</property>
+                                            <property name="wrap">False</property>
                                             <property name="selectable">True</property>
                                             <property name="ellipsize">end</property>
                                             <property name="width-chars">40</property>
                                             <property name="max-width-chars">80</property>
-                                            <property name="lines">2</property>
+                                            <property name="lines">1</property>
                                             <attributes>
                                               <attribute name="stretch" value="ultra-condensed"/>
                                             </attributes>


### PR DESCRIPTION
In recent kernel versions, some GPUs as for example 3rd Gen Intel HD have very long name description which causes a wrap in the text box on Fedora 41 Beta which doesn't have a condensed font by default. Ubuntu 24.10 Beta has the condensed font and the name almost fits in the text box